### PR TITLE
Revert "Improve Yocto integration"

### DIFF
--- a/external.xml
+++ b/external.xml
@@ -27,9 +27,7 @@
   <extend-project name="camkes-vm-examples.git"         remote="tiiuae" revision="rpi4"/>
   <extend-project name="camkes-vm-linux.git"            remote="tiiuae" revision="rpi4"/>
   <extend-project name="camkes-vm.git"                  remote="tiiuae" revision="rpi4"/>
+  <extend-project name="camkes-vm-images.git"           remote="tiiuae" revision="rpi4"/>
   <extend-project name="seL4_projects_libs.git"         remote="tiiuae" revision="rpi4"/>
   <extend-project name="capdl.git"                      remote="tiiuae" revision="rpi4"/>
-
-  <remove-project name="camkes-vm-images.git"/>
-  <project remote="tiiuae" name="camkes-vm-yocto-images.git" path="projects/camkes-vm-images" revision="main"/>
 </manifest>


### PR DESCRIPTION
This reverts commit 877ffdef84ac2cd59312b28d4e0258b5d07111e1.

The use of Yocto images is not suitable for all target builds, such as vm_minimal, vm_multi etc. Where Yocto images are required, the project should point directly to the location of the images (i.e. make assumption for the location), and have means for overriding the defaults.

See https://github.com/tiiuae/tii-sel4-vm/pull/23 for example.